### PR TITLE
Minimal QOL Improvements

### DIFF
--- a/lua/dingllm.lua
+++ b/lua/dingllm.lua
@@ -142,6 +142,7 @@ function M.handle_anthropic_spec_data(data_stream)
     elseif event == 'content_block_stop' then
     elseif event == 'message_start' then
       vim.print(data)
+    elseif event == 'message_stop' then
     elseif event == 'message_delta' then
     elseif event == 'ping' then
     elseif event == 'error' then

--- a/lua/dingllm.lua
+++ b/lua/dingllm.lua
@@ -61,7 +61,12 @@ function M.make_anthropic_spec_curl_args(opts, prompt, system_prompt)
     stream = true,
     max_tokens = 4096,
   }
-  local args = { '-N', '-X', 'POST', '-H', 'Content-Type: application/json', '-d', vim.json.encode(data) }
+  local args = {
+    '-s', '--fail-with-body', '-N', --silent, with errors, unbuffered output
+    '-X', 'POST',
+    '-H', 'Content-Type: application/json',
+    '-d', vim.json.encode(data)
+  }
   if api_key then
     table.insert(args, '-H')
     table.insert(args, 'x-api-key: ' .. api_key)
@@ -81,7 +86,12 @@ function M.make_openai_spec_curl_args(opts, prompt, system_prompt)
     temperature = 0.7,
     stream = true,
   }
-  local args = { '-N', '-X', 'POST', '-H', 'Content-Type: application/json', '-d', vim.json.encode(data) }
+  local args = {
+    '-s', '--fail-with-body', '-N', --silent, with errors, unbuffered output
+    '-X', 'POST',
+    '-H', 'Content-Type: application/json',
+    '-d', vim.json.encode(data)
+  }
   if api_key then
     table.insert(args, '-H')
     table.insert(args, 'Authorization: Bearer ' .. api_key)


### PR DESCRIPTION
main reason i felt like doing this is because i discovered `vim.system` exists so it would remove the only dependency

---

been working on `kznllm` for a while and discovered some neat patterns to keep neovim plugins minimal _without_ compromising on user experience...

here's an overview of improvements + changes I'd make on the original dingllm to either
(1) make the code cleaner or
(2) add baseline QOL features

---

high-level overview

1. remove plenary (less dependencies = good, but only supported in `nvim 0.10` i believe)
    - simplified parsing due to replacing plenary with `vim.system` (don't worry it's async)
    - note: plenary was forcing the stdout buffer to split lines, which forces us to write weird parsing logic for anthropic
2. propagate errors so that the API never fails silently
3. free the cursor so the user can keep working
4. noop to deal with `undojoin` error

<img width="951" alt="Screenshot 2024-11-23 at 11 14 36 AM" src="https://github.com/user-attachments/assets/5c9497fa-9d98-4fed-97cb-fd769876c9de">

---

Other baseline things not added here because it would make it too long (and why i wrote kznllm in the first place):
- model switcher
- separate buffer mode
- prompt templates